### PR TITLE
Remove accelerator from an Italian string

### DIFF
--- a/Translations/Italiano (Italia).csv
+++ b/Translations/Italiano (Italia).csv
@@ -289,7 +289,7 @@ TRANSLATED
 "Alignment"	"Allineamento"	"label"
 "All Files (*.*)"	"Tutti i file (*.*)"	"combobox.1006"
 "All Files (*.*)|*.*||"	"Tutti i file (*.*)|*.*||"	"text"
-"All Tasks"	"&Tutti i compiti"	"menu.32986"
+"All Tasks"	"Tutti i compiti"	"menu.32986"
 "All Tasks"	"&Tutti i compiti"	"menu.32987"
 "All attributes"	"Tutti gli attributi"	"radiobutton.1249"
 "All open tasklists"	"Tutte le liste di compiti aperte"	"combobox.1114"


### PR DESCRIPTION
An unwanted "&" is shown in a dropdown menu